### PR TITLE
Update Middleware URL for AWS

### DIFF
--- a/src/config/config.js
+++ b/src/config/config.js
@@ -79,9 +79,7 @@ const EQUATION_EDITOR_AUTO_COMMANDS =
     "pi theta sqrt sum prod int alpha beta gamma rho nthroot pm";
 const EQUATION_EDITOR_AUTO_OPERATORS = "sin cos tan";
 
-const MIDDLEWARE_URL =
-    process.env.REACT_APP_MIDDLEWARE_URL ||
-    "https://oatutor.askoski.berkeley.edu";
+const MIDDLEWARE_URL = "https://di2iygvxtg.execute-api.us-west-1.amazonaws.com/prod";
 
 const HELP_DOCUMENT =
     "https://docs.google.com/document/d/e/2PACX-1vToe2F3RiCx1nwcX9PEkMiBA2bFy9lQRaeWIbyqlc8W_KJ9q-hAMv34QaO_AdEelVY7zjFAF1uOP4pG/pub";


### PR DESCRIPTION
configuring frontend to make requests to the AWS lambda endpoint instead of the Maxwell server