### PR TITLE
Fix issue where keyboard will not fully open

### DIFF
--- a/src/components/problem-input/ProblemInput.css
+++ b/src/components/problem-input/ProblemInput.css
@@ -3,7 +3,6 @@ body {
     --keyboard-accent-color: #8C94FF;
     --keycap-background-hover: #8C94FF;
     --keycap-secondary-background: #8C94FF;
-    --keycap-height: 12px;
     --keycap-font-size: 24px;
     --keycap-shift-font-size: 14px;
     --keycap-small-font-size: 14px;


### PR DESCRIPTION
The issue seems to stem from the custom keycap height. Removing it solved the visual error.