### PR TITLE
Clamp input validation values to a smaller range

### DIFF
--- a/src/kas.js
+++ b/src/kas.js
@@ -1895,8 +1895,15 @@ _.extend(Expr.prototype, {
             var useFloats = i % 2 === 0;
 
             _.each(varList, function(v) {
-                vars[v] = useFloats ? randomFloat(-range, range)
+                // ahaim:
+                // We clamp the range to avoid a precision issue with function
+                // exponents, but this should eventually be replaced with a
+                // proper solution to mitigate precision calculations altogether.
+                var value = useFloats ? randomFloat(-range, range)
                                     : _.random(-range, range);
+                if (value > 250) value = 250;
+                if (value < -250) value = -250;
+                vars[v] = value;
             });
 
             var equal;


### PR DESCRIPTION
Clamps the inputs used to test whether one expression is functionally equivalent to the answer to a smaller range to avoid potential precision issues with exponents. Granted, this is not a full-proof solution, so a note is added to address this at a future time. However, this should reduce the collision significantly.