### PR TITLE
Fix BKT params naming: use defaultBKTParams and experimentalBKTParams

### DIFF
--- a/.github/workflows/deploy-content-staging.yml
+++ b/.github/workflows/deploy-content-staging.yml
@@ -57,8 +57,8 @@ jobs:
         cd content-staging-build/src/content-sources/oatutor
         mv "OpenStax Content" "content-pool"
         mkdir -p bkt-params
-        mv bktParams.json bkt-params/bktParams1.json
-        cp bkt-params/bktParams1.json bkt-params/bktParams2.json
+        mv bktParams.json bkt-params/defaultBKTParams.json
+        cp bkt-params/defaultBKTParams.json bkt-params/experimentalBKTParams.json
 
     - name: Run Node.js preprocessing script
       run: |

--- a/src/App.js
+++ b/src/App.js
@@ -37,8 +37,8 @@ import TabFocusTrackerWrapper from "./components/TabFocusTrackerWrapper";
 // ### BEGIN CUSTOMIZABLE IMPORTS ###
 import config from "./config/firebaseConfig.js";
 import skillModel from "./content-sources/oatutor/skillModel.json";
-import bktParams1 from "./content-sources/oatutor/bkt-params/bktParams1.json";
-import bktParams2 from "./content-sources/oatutor/bkt-params/bktParams2.json";
+import defaultBKTParams from "./content-sources/oatutor/bkt-params/defaultBKTParams.json";
+import experimentalBKTParams from "./content-sources/oatutor/bkt-params/experimentalBKTParams.json";
 import { heuristic as lowestHeuristic } from "./models/BKT/problem-select-heuristics/problemSelectHeuristic1.js";
 import { heuristic as highestHeuristic } from "./models/BKT/problem-select-heuristics/problemSelectHeuristic2.js";
 import BrowserStorage from "./util/browserStorage";
@@ -61,8 +61,8 @@ const queryParamsToKeep = ["use_expanded_view", "to", "do_not_restore"];
 
 const treatmentMapping = {
     bktParams: {
-        0: cleanObjectKeys(bktParams1),
-        1: cleanObjectKeys(bktParams2),
+        0: cleanObjectKeys(defaultBKTParams),
+        1: cleanObjectKeys(experimentalBKTParams),
     },
     heuristic: {
         0: lowestHeuristic,


### PR DESCRIPTION
## Summary
- Update `deploy-content-staging.yml` to generate `defaultBKTParams.json` and `experimentalBKTParams.json` instead of `bktParams1.json`/`bktParams2.json`
- Update `App.js` imports to match the new filenames

## Why
The incremental update workflow was generating files with the new names (`defaultBKTParams`/`experimentalBKTParams`) but `content-staging`'s `App.js` was still importing the old names (`bktParams1`/`bktParams2`). This caused the build to silently fall back to stale BKT params, resulting in BKT parameter console errors and lessons not rendering correctly.

This fix was originally made on `fix-bktparams-for-content-staging` (commit 4d11d9d7dd) but was never merged into `content-staging`.

## Test plan
- [ ] Trigger the incremental content update workflow after merge
- [ ] Verify no "BKT Parameter does not exist" errors in browser console
- [ ] Verify lessons render and problems can be answered