### PR TITLE
Restore defaultBKTParams before incremental update so old skills are preserved

### DIFF
--- a/.github/workflows/incremental-content-update.yml
+++ b/.github/workflows/incremental-content-update.yml
@@ -50,6 +50,9 @@ jobs:
           mv "content-pool" "OpenStax Content"
         fi
         mkdir -p Content
+        if [ -f "bkt-params/defaultBKTParams.json" ]; then
+          cp bkt-params/defaultBKTParams.json bktParams.json
+        fi
 
     - name: Run content update script
       run: |


### PR DESCRIPTION
## Summary
- In the incremental update workflow, `lesson.py` looks for `../bktParams.json` to load and merge existing skills from the previous run
- The file is stored as `bkt-params/defaultBKTParams.json` but was never restored to `bktParams.json` before the script ran
- This caused every incremental run to start with empty `old_bkt_params`, dropping all skills from unchanged sheets
- Result: `defaultBKTParams.json` only contained skills from sheets that changed in that run, causing BKT parameter errors in the browser

## Fix
Add a restore step in "Prepare for incremental update" that copies `defaultBKTParams.json` back to `bktParams.json` before running the script, so `lesson.py` can find and merge the existing skills.

## Test plan
- [ ] Run incremental update workflow
- [ ] Verify no "BKT Parameter does not exist" errors in browser console
- [ ] Verify lessons render correctly