### PR TITLE
Handle edge cases in problem tolerances

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,6 +333,13 @@ DO_FOCUS_TRACKING = false;
 * `GridInput`: Provides a grid for the student to fill out. Must have `numRows` and `numCols` for the answer size, while the `stepAnswer` must be a list of lists of strings: `"[[\"1\",\"2\"],[\"3\",\"4\"]]"` for a 2x2 grid. Must have `answerType: "string"`.
 * `MatrixInput`: Provides a matrix for the student to fill out. Must have `numRows` and `numCols` for the answer size, while the `stepAnswer` must be a list of lists of strings: `"[[\"1\",\"2\"],[\"3\",\"4\"]]"` for a 2x2 grid. Must have `answerType: "string"`.
 
+### Answer Validation
+
+Due to the numerous different ways an arithmetic expression can be an answer, OATutor performs some additional validation on the student's answer to make sure they are not copying and pasting the problem body into the answer box. However, the backing evaluator does not always identify the question and answer text as unique states from different inputs. For this, steps and scaffolds have an optional `answerValidator` field that can take in one the following values:
+
+* `default`: Checks whether the representation of the problem is not the same as the representation of the student's answer. This is the default behavior in OATutor.
+* `simplified`: Compares whether the question does not contain the student's answer, and that the student's answer is in it's simplest form. This should be used for problems that convert one form of an expression to another equivalent form (e.g., convert the fifth root of x to its exponent representation).
+
 ### Example Directory Structure
 
 ```

--- a/README.md
+++ b/README.md
@@ -388,7 +388,9 @@ content-sources/
     "stepTitle": "1. Maximum Radius",
     "stepBody": "What is the maximum radius of a circular rug that will fit in the room?",
     "answerType": "numeric",
-    "variabilization": {}
+    "variabilization": {},
+    // Can be either 'default' or 'simplified'
+    "answerValidator": "default"
 }
 ```
 
@@ -413,7 +415,9 @@ content-sources/
         "answerType": "numeric",
         "type": "scaffold",
         "dependencies": [0],
-        "variabilization": {}
+        "variabilization": {},
+        // Can be either 'default' or 'simplified'
+        "answerValidator": "default"
     },
     {
         "id": "circle1a-h3",

--- a/src/components/problem-layout/HintTextbox.js
+++ b/src/components/problem-layout/HintTextbox.js
@@ -48,7 +48,8 @@ class HintTextbox extends React.Component {
             answerType: this.hint.answerType,
             precision: this.hint.precision,
             variabilization: chooseVariables(this.props.hintVars, this.props.seed),
-            questionText: this.hint.text
+            questionText: this.hint.text,
+            answerValidator: this.hint.answerValidator
         });
 
         if (parsed == '') {

--- a/src/components/problem-layout/ProblemCard.js
+++ b/src/components/problem-layout/ProblemCard.js
@@ -256,6 +256,7 @@ class ProblemCard extends React.Component {
                 seed
             ),
             questionText: stepBody.trim() || stepTitle.trim(),
+            answerValidator: this.step.answerValidator
         });
 
         const isCorrect = !!correctAnswer;
@@ -472,6 +473,7 @@ class ProblemCard extends React.Component {
             ),
             questionText:
                 this.step.stepBody.trim() || this.step.stepTitle.trim(),
+            answerValidator: this.step.answerValidator
         });
     
         const isCorrect = !!correctAnswer;

--- a/src/platform-logic/checkAnswer.js
+++ b/src/platform-logic/checkAnswer.js
@@ -91,6 +91,59 @@ function convertSwedishToUS(numberString) {
 }
 
 /**
+ * A map of validators types to their functions
+ */
+const ANSWER_VALIDATORS = {
+    // Checks if the representation of the parsed text is not the same as the representation of the question
+    "default": (questionText, attempt, parsed) => parse(questionText).expr.repr() !== parsed.repr(),
+    // Checks if the question text doesn't include the attempt and that the parsed answer is in its simplest form
+    "simplified": (questionText, attempt, parsed) => !questionText.includes(attempt) && parsed.normalize().repr() === parsed.simplify().normalize().repr()
+}
+
+/**
+ * 
+ * @param {string} attempt 
+ * @param {string[]} actual 
+ * @returns 
+ */
+function checkExplicitAnswerText(attempt, actual) {
+    // First check if they are exactly the same
+    let checker = actual.filter((actualAns) => attempt === actualAns);
+    if (checker.length > 0) {
+        return [true, checker[0]];
+    }
+
+    // If not, remove any leading or trailing dollar signs from actual answer
+    let cleanedActual = actual.map((actualAns) => {
+        if (actualAns.startsWith('$$')) actualAns = actualAns.substring(2);
+        if (actualAns.endsWith('$$')) actualAns = actualAns.substring(0, actualAns.length - 2);
+        return actualAns;
+    })
+    checker = cleanedActual.filter((actualAns) => attempt === actualAns);
+    if (checker.length > 0) {
+        return [true, checker[0]];
+    }
+
+    // Check without parentheses
+    cleanedActual = cleanedActual.map((actualAns) => {
+        return actualAns.replaceAll(/\s+/g, '').replaceAll(/\\left\(/g, '').replaceAll(/\\right\)/g, '')
+    })
+    checker = cleanedActual.filter((actualAns) => attempt === actualAns);
+    if (checker.length > 0) {
+        return [true, checker[0]];
+    }
+
+    // Maybe attempt needs to be cleaned
+    let cleanedAttempt = attempt.replaceAll(/\s+/g, '').replaceAll(/\\left\(/g, '').replaceAll(/\\right\)/g, '')
+    if (cleanedAttempt !== attempt) {
+        return checkExplicitAnswerText(cleanedAttempt, actual);
+    }
+
+    // Otherwise, they are likely not the same
+    return [false, false];
+}
+
+/**
  *
  * @param attempt
  * @param actual
@@ -98,9 +151,15 @@ function convertSwedishToUS(numberString) {
  * @param precision
  * @param variabilization
  * @param questionText {string} allows for a check to see if student pasted in the answer exactly
+ * @param answerValidator Specifies the validator method to use when determining if an answer is considered the same as a problem
  * @returns {[string, boolean | string, null | WrongAnswerReasons]}
  */
-function checkAnswer({ attempt, actual, answerType, precision = 5, variabilization = {}, questionText = ""}) {
+function checkAnswer({ attempt, actual, answerType, precision = 5, variabilization = {}, questionText = "", answerValidator = "default"}) {
+    // Make sure the validation method used is never null or undefined
+    if (answerValidator == null) {
+        answerValidator = "default";
+    }
+
     if (localStorage.getItem('locale') == 'se') {
         attempt = convertSwedishToUS(attempt)
     }
@@ -155,8 +214,15 @@ function checkAnswer({ attempt, actual, answerType, precision = 5, variabilizati
 
                 // try to see if student paste in exact question
                 try {
-                    const questionTextRepr = parse(questionText).expr.repr()
-                    if (questionTextRepr === parsed.repr()) {
+                    if (!ANSWER_VALIDATORS[answerValidator](questionText, attempt, parsed)) {
+                        // If validators think that the problem text is similar to the answer, it might
+                        // be a problem that we need to explicitly check the answer text for (e.g.,
+                        // converting number representations to another form).
+                        const [matches, correctAnswer] = checkExplicitAnswerText(attempt, actual);
+                        if (matches) {
+                            return [parsed.print(), correctAnswer, null];
+                        }
+
                         return [parsed.print(), false, WrongAnswerReasons.sameAsProblem];
                     }
                 } catch (_) {


### PR DESCRIPTION
Fixes two edge cases when validating an answer for a numeric step or scaffold.

First, adds a new `answerValidator` field that can currently be set to `default` or `simplified`. `default` will behave like OATutor has been, while `simplified` will first check if the question includes the answer and if the answer is in its simplest represented form. If no field is set, this defaults to `default`.

`simplified` should capture most conversion problems; however, there are a few that it cannot. These are when there are no variables in the equation, meaning that any simplification will evaluate to a number. As such, in these instances, there is an additional check that directly checks the answer string against the attempt string, first normally, next without `$$`, and finally without parentheses. If all of these fail, only then will `checkAnswer` return a failure.