### PR TITLE
ci(content-staging): source experimental BKT params from tooling

### DIFF
--- a/.github/workflows/deploy-content-staging.yml
+++ b/.github/workflows/deploy-content-staging.yml
@@ -59,7 +59,10 @@ jobs:
         mv "OpenStax Content" "content-pool"
         mkdir -p bkt-params
         mv bktParams.json bkt-params/defaultBKTParams.json
-        cp /home/runner/work/OATutor-Tooling/bkt/output/experimentalBKTParams.json bkt-params/experimentalBKTParams.json
+        python3 /home/runner/work/OATutor-Tooling/bkt/merge_experimental.py \
+          --default bkt-params/defaultBKTParams.json \
+          --fitted /home/runner/work/OATutor-Tooling/bkt/output/experimentalBKTParams.json \
+          --out bkt-params/experimentalBKTParams.json
 
     - name: Run Node.js preprocessing script
       run: |

--- a/.github/workflows/deploy-content-staging.yml
+++ b/.github/workflows/deploy-content-staging.yml
@@ -59,7 +59,7 @@ jobs:
         mv "OpenStax Content" "content-pool"
         mkdir -p bkt-params
         mv bktParams.json bkt-params/defaultBKTParams.json
-        cp bkt-params/defaultBKTParams.json bkt-params/experimentalBKTParams.json
+        cp /home/runner/work/OATutor-Tooling/bkt/output/experimentalBKTParams.json bkt-params/experimentalBKTParams.json
 
     - name: Run Node.js preprocessing script
       run: |


### PR DESCRIPTION
Instead of duplicating defaultBKTParams into the experimental slot (which made the A/B groups identical), copy experimentalBKTParams.json from the OATutor-Tooling repo already cloned in the workflow. Control group keeps the freshly generated params; experimental group gets the fitted params.