### PR TITLE
ci(incremental): merge fitted experimental BKT params instead of copying default

### DIFF
--- a/.github/workflows/incremental-content-update.yml
+++ b/.github/workflows/incremental-content-update.yml
@@ -65,7 +65,10 @@ jobs:
         mv "OpenStax Content" "content-pool"
         mkdir -p bkt-params
         mv bktParams.json bkt-params/defaultBKTParams.json
-        cp bkt-params/defaultBKTParams.json bkt-params/experimentalBKTParams.json
+        python3 /home/runner/work/OATutor-Tooling/bkt/merge_experimental.py \
+          --default bkt-params/defaultBKTParams.json \
+          --fitted /home/runner/work/OATutor-Tooling/bkt/output/experimentalBKTParams.json \
+          --out bkt-params/experimentalBKTParams.json
 
     - name: Run Node.js preprocessing script
       run: |


### PR DESCRIPTION
Companion to #118, for the second workflow that runs on the same cron.

`incremental-content-update.yml` ("Automated Content Update (Partial)") ends its "Move and prepare files" step with `cp defaultBKTParams.json experimentalBKTParams.json`, which makes the two A/B slots byte-identical and discards any fitted values in the experimental slot. This replaces that copy with `bkt/merge_experimental.py` from the already-cloned OATutor-Tooling checkout: for each KC in the freshly generated default file it takes the fitted value where one exists and falls back to default's own value otherwise, so experimental tracks default's live KC set (new KCs added, removed/renamed KCs dropped) while keeping tuned values.

Safe on the incremental path specifically because the "Prepare for incremental update" step (added in #110) restores `defaultBKTParams.json` back to `bktParams.json` before `final.py` runs, so by the time the merge executes, default holds the full KC set rather than only the sheets that changed in that run.

**Depends on** CAHLR/OATutor-Tooling#16, which adds `bkt/merge_experimental.py` and `bkt/output/experimentalBKTParams.json`. The workflow clones tooling's default branch, so that PR must merge first or the step will fail.

## Test plan
- [ ] Merge CAHLR/OATutor-Tooling#16 first
- [ ] `workflow_dispatch` this workflow and confirm the merge step reports the fitted-KC count
- [ ] Verify `experimentalBKTParams.json` on `content-staging` differs from `defaultBKTParams.json` and has the same KC set
- [ ] No "BKT Parameter does not exist" errors in the browser console

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Uq7T4wTcGUWnMAbKyPHQ3