### PR TITLE
ci(staging-v2): merge fitted experimental BKT params instead of copying default

### DIFF
--- a/.github/workflows/staging-content-update.yml
+++ b/.github/workflows/staging-content-update.yml
@@ -56,7 +56,10 @@ jobs:
         mv "OpenStax Content" "content-pool"
         mkdir -p bkt-params
         mv bktParams.json bkt-params/defaultBKTParams.json
-        cp bkt-params/defaultBKTParams.json bkt-params/experimentalBKTParams.json
+        python3 /home/runner/work/OATutor-Tooling/bkt/merge_experimental.py \
+          --default bkt-params/defaultBKTParams.json \
+          --fitted /home/runner/work/OATutor-Tooling/bkt/output/experimentalBKTParams.json \
+          --out bkt-params/experimentalBKTParams.json
     - name: Run Node.js preprocessing script
       run: |
         cd content-staging-build/src/tools


### PR DESCRIPTION
Companion to #118 and #126 — the third and last content workflow carrying the same line.

`staging-content-update.yml` (branch `staging-v2`, same `0 3,15 * * *` cron) ends its "Move and prepare files" step with `cp defaultBKTParams.json experimentalBKTParams.json`, making the two A/B slots byte-identical and discarding any fitted values. This replaces the copy with `bkt/merge_experimental.py` from the already-cloned OATutor-Tooling checkout: for each KC in the freshly generated default file it takes the fitted value where one exists, else default's own value — so experimental tracks default's live KC set while keeping tuned values.

This is a full run (`rm -rf` of the content dir followed by `final.py online full`), so default is complete by construction and no restore step is needed, unlike the incremental path in #126.

**Depends on** CAHLR/OATutor-Tooling#16, which adds `bkt/merge_experimental.py` and `bkt/output/experimentalBKTParams.json`. The workflow clones tooling's default branch, so that PR must merge first or the step will fail.

## Test plan
- [ ] Merge CAHLR/OATutor-Tooling#16 first
- [ ] `workflow_dispatch` this workflow and confirm the merge step reports the fitted-KC count
- [ ] Verify `experimentalBKTParams.json` on `staging-v2` differs from `defaultBKTParams.json` and has the same KC set
- [ ] No "BKT Parameter does not exist" errors in the browser console

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Uq7T4wTcGUWnMAbKyPHQ3